### PR TITLE
Fix capitalization of rdfs:subClassOf

### DIFF
--- a/Assignment 2/Assignment 2. Manipulating RDF data.ipynb
+++ b/Assignment 2/Assignment 2. Manipulating RDF data.ipynb
@@ -324,7 +324,7 @@
    "source": [
     "### Task 3) (2 Points) Visualising implicit knowledge (a bit of schema)\n",
     "\n",
-    "We will look into Schema information in the latter modules, but let us try already to find some implicit information in a first bit of inferencing: whenver there are two statements (s a o) and (o rdfs:subclassOf o2) we can derive (and later prove) that (s a o2). \n",
+    "We will look into Schema information in the latter modules, but let us try already to find some implicit information in a first bit of inferencing: whenver there are two statements (s a o) and (o rdfs:subClassOf o2) we can derive (and later prove) that (s a o2). \n",
     "\n",
     "Write a procedure that adds all implied triples for our knowledge base. \n",
     "\n",


### PR DESCRIPTION
Task 3 of assignment 2 had an error in its description, where the capitalization of one predicate had one lowercase letter that should be uppercase. Since these things are case-sensitive, this will result in an error if used as-is.